### PR TITLE
minor amendments to inventory use case

### DIFF
--- a/use-cases/inventory.md
+++ b/use-cases/inventory.md
@@ -20,7 +20,7 @@ In order to synchronize products with Mews POS, use the [Get products](../operat
 GET [PlatformAddress]/api/v2/products
 ```
 
-Further detail can be obtained via linked entities such as `productType` (e.g. food or beverage), `modifierSets` (product qualifiers, such as pizza toppings) and `productVariants`. These can be included in the response by using the same request but specifying the relevant include query parameters – see [Essential guide > Relationships](../essential-guide/relationships.md).
+Further detail can be obtained via linked entities such as `productType` (e.g. food or beverage), `modifierSets` (chargeable product qualifiers, such as pizza toppings) and `productVariants`. These can be included in the response by using the same request but specifying the relevant include query parameters – see [Essential guide > Relationships](../essential-guide/relationships.md).
 
 #### Example request:
 
@@ -214,12 +214,8 @@ GET [PlatformAddress]/api/v2/registers/eef23c03-49b9-432b-b1a3-955ea1501557?incl
 
 ## Frequently Asked Questions
 
-<!-- * [What does the fieldset query parameter do?]() -->
-<!-- * [Where is Product ID in invoice items?]() -->
-<!-- * [Why are you using snake_case when JSON:API recommends camelCase?]() -->
 * [How do you represent returns and cancellations?](#how-do-you-represent-returns-and-cancellations)
 * [How do you represent waste?](#how-do-you-represent-waste)
-* [Are open orders included in the API?](#are-open-orders-included-in-the-API)
 * [How do you represent modifiers and add-ons?](#how-do-you-represent-modifiers-and-add-ons)
 * [How do you represent combo deals?](#how-do-you-represent-combo-deals)
 
@@ -233,20 +229,16 @@ _How do you represent waste, e.g. a dropped plate in the kitchen, or a spoiled i
 
 * __Answer__: We currently don't have any specific provision for waste.
 
-### Are open orders included in the API?
-_Are open orders included in the API as well, or is the state of every order final?_
-
-* __Answer__: No, only final orders are represented.
-
 ### How do you represent modifiers and add-ons?
 _How do you represent modifiers and add-ons, e.g. extra cheese, no tomatoes?_
 
 * __Answer__: We use invoice item modifiers for this. Invoice items are related to an `invoice` resource, and this has a relationship of its own to the invoice item modifiers which you'll get if you _include_ invoice items in the response – see [Essential guide > Relationships](../essential-guide/relationships.md).
+Note only modifiers with an attached price tag (e.g. extra pizza toppings) are included in invoice items, not non-chargeable modifiers (e.g. steak cooked medium-rare).
 
 ### How do you represent combo deals?
 _How do you represent menu items and combo deals, e.g. Lunch combo Burger+Cola+Fries?_
 
-* __Answer__: In addition to product variants, __Mews POS__ supports product bundles, which could be used for combo deals. Product variants are supported in relation to the `product` resource. Product bundles are not currently supported in the API.
+* __Answer__: In addition to product variants, __Mews POS__ supports product bundles, which could be used for combo deals. Product variants are supported in relation to the `product` resource. Product bundles are not currently supported in the API, but will be added shortly.
 
 ## Additional help
 


### PR DESCRIPTION
### Summary

* Updates to Inventory Management use case:
  * Removed FAQ item "Are open orders included in the API?"
  * Updated FAQ item related to combo deals to say that we plan to add product bundles to the API in future
  * Added comments to the effect that only chargeable modifiers are returned as part of an invoice

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] Changelog dated the day when PR merged
- [ ] Changelog accurately describes all changes
- [ ] Changelog highlights the affected endpoints or operations
- [ ] Changelog highlights any deprecations
- [ ] All hyperlinks tested
- [ ] Deprecation Table updated if any deprecations
- [ ] SUMMARY.md updated if new pages added
