### PR TITLE
Release latest documentation

### DIFF
--- a/_generator/types.yaml
+++ b/_generator/types.yaml
@@ -291,3 +291,11 @@ types:
     file: webhookendpoints.md
     anchor: webhook_endpoint_create
     tag: WebhookEndpoints
+  Tables_area_relationships:
+    file: tables.md
+    anchor: area_relationships
+    tag: Tables
+  Orders_area_relationships:
+    file: orders.md
+    anchor: area_relationships
+    tag: Orders

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 21st February 2025
+* Updated booking [relationship](../operations/bookings.md#Response) with orders (multiple orders now related to booking instead of one).
+* Added list of [booking statuses.](../operations/bookings.md#booking_attributes)
+* Added two new fields, `depositAmount` and `isWalkIn`, for [booking attributes.](../operations/bookings.md#booking_attributes)
+* Updated bookings list endpoint [filters.](../operations/bookings.md#get_bookings)
+* Updated product status [enum list.](../operations/products.md#product_attributes)
+* Update tables relationships, now it is related to `area`.
+* General improvements for webhook endpoint[ documentation page.](../operations/webhookendpoints.md)
+
 ## 20th February 2025
 * Added [API Events](../events/README.md), [Webhooks](../events/webhooks.md) and [Webhook security](../events/wh-security.md)
 

--- a/operations/bookings.md
+++ b/operations/bookings.md
@@ -66,10 +66,12 @@ This operation updates a booking.
     },
     "relationships": {
       "orders": {
-        "data": {
-          "id": "5efa8b3c-b930-4b31-918d-95ab0e212e65",
-          "type": "orders"
-        }
+        "data": [
+          {
+            "id": "5efa8b3c-b930-4b31-918d-95ab0e212e65",
+            "type": "orders"
+          }
+        ]
       },
       "customer": {
         "data": {
@@ -108,7 +110,7 @@ Below is a list of all possible fields this endpoint can return including relati
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `status` | string,null | optional | The initial status of the booking. |
+| `status` | string,null | optional | The initial status of the booking. Possible values are "confirmed", "seated", "completed", "cancelled", and "noShow". |
 | `partySize` | integer | required | Represents the number of people included in the booking. |
 | `bookingDatetime` | string | required, max length 25 characters | The booking's date. |
 | `duration` | integer,null | optional | Represents the length of the booking in minutes. |
@@ -116,6 +118,8 @@ Below is a list of all possible fields this endpoint can return including relati
 | `roomNumber` | string,null | optional, max length 100 characters | The room number of the booking's customer. |
 | `promotions` | string,null | optional, max length 100 characters | The promotions of the booking. |
 | `bookingReference` | string,null | optional, max length 255 characters | A reference code or identifier associated with the booking. |
+| `isWalkIn` | boolean | required | Indicates if the booking is a walk-in. |
+| `depositAmount` | string,null | optional, max length 255 characters | The amount of the deposit. |
 
 #### booking_relationships
 
@@ -132,7 +136,7 @@ This operation returns a list of bookings.
 **Note**: This operation needs [Authentication](../guidelines/authentication.md) and supports the following JSON:API features:
 
 - [Relationships](../guidelines/relationships.md) - `customer`, `orders`, `tables` using `include` query parameter.
-- [Filters](../guidelines/filtering.md) - `createdAtGt`, `createdAtGteq`, `createdAtLt`, `createdAtLteq`, `updatedAtGt`, `updatedAtGteq`, `updatedAtLt`, `updatedAtLteq`
+- [Filters](../guidelines/filtering.md) - `createdAtGt`, `createdAtGteq`, `createdAtLt`, `createdAtLteq`, `updatedAtGt`, `updatedAtGteq`, `updatedAtLt`, `updatedAtLteq`, `bookingDatetimeGt`, `bookingDatetimeGteq`, `bookingDatetimeLt`, `bookingDatetimeLteq`
 - [Sparse fieldsets](../guidelines/sparse-fieldsets.md) - supports all fields of `booking` query parameter.
 
 ### Request

--- a/operations/orders.md
+++ b/operations/orders.md
@@ -87,7 +87,7 @@ Below is a list of all possible fields this endpoint can return including relati
 | `notes` | string,null | optional, max length 500 characters | Notes about the order. |
 | `covers` | undefined | required | How many people are seated at the table. |
 | `depositAmount` | string,null | optional, max length 255 characters | The amount of discount applied to the invoice. |
-| `tableStatus` | string,null | optional | Status of the table. |
+| `tableStatus` | string,null | optional | Status of the table. Possible values are "noTable", "seated", "cleaning", and "free". |
 | `createdAt` | string | required, max length 25 characters | Order created at timestamp in RFC 3339 format. |
 | `updatedAt` | string | required, max length 25 characters | Order updated at timestamp in RFC 3339 format. |
 
@@ -142,6 +142,7 @@ Below is a list of all possible fields this endpoint can return including relati
 | `id` | string | required, max length 36 characters | Universally unique ID (UUID) that identifies the related object. |
 | `type` | string | required | The [type](https://jsonapi.org/format/#document-resource-object-identification) member is used to describe resource objects that share common attributes and relationships. |
 | `attributes` | [table_attributes](orders.md#table_attributes) | required | An [attributes object](https://jsonapi.org/format/#document-resource-object-attributes) representing some of the resource's data. |
+| `relationships` | [area_relationships](orders.md#area_relationships) | required | A [relationships object](https://jsonapi.org/format/#document-resource-object-relationships) describing relationships between the resource and other JSON:API resources. |
 
 #### table_attributes
 
@@ -151,6 +152,12 @@ Below is a list of all possible fields this endpoint can return including relati
 | `numberOfSeats` | integer | required | Number of seats for the table. |
 | `createdAt` | string | required, max length 25 characters | Created at timestamp in RFC 3339 format. |
 | `updatedAt` | string | required, max length 25 characters | Updated at timestamp in RFC 3339 format. |
+
+#### area_relationships
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `area` | object | required | Details of the table area. |
 
 #### booking
 
@@ -165,7 +172,7 @@ Below is a list of all possible fields this endpoint can return including relati
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `status` | string,null | optional | The initial status of the booking. |
+| `status` | string,null | optional | The initial status of the booking. Possible values are "confirmed", "seated", "completed", "cancelled", and "noShow". |
 | `partySize` | integer | required | Represents the number of people included in the booking. |
 | `bookingDatetime` | string | required, max length 25 characters | The booking's date. |
 | `duration` | integer,null | optional | Represents the length of the booking in minutes. |
@@ -173,6 +180,8 @@ Below is a list of all possible fields this endpoint can return including relati
 | `roomNumber` | string,null | optional, max length 100 characters | The room number of the booking's customer. |
 | `promotions` | string,null | optional, max length 100 characters | The promotions of the booking. |
 | `bookingReference` | string,null | optional, max length 255 characters | A reference code or identifier associated with the booking. |
+| `isWalkIn` | boolean | required | Indicates if the booking is a walk-in. |
+| `depositAmount` | string,null | optional, max length 255 characters | The amount of the deposit. |
 
 #### booking_relationships
 

--- a/operations/products.md
+++ b/operations/products.md
@@ -101,7 +101,7 @@ Below is a list of all possible fields this endpoint can return including relati
 | `description` | string | required, max length 10000 characters | Description of the product. |
 | `sku` | string | required, max length 255 characters | SKU of the product. |
 | `barcode` | string | required, max length 255 characters | Barcode of the product. |
-| `status` | string | required | Status of the product. |
+| `status` | string | required | Status of the product. Possible values are "active" and "inactive". |
 | `tax` | string | required, max length 255 characters | Tax of the product. |
 | `retailPriceExclTax` | string | required, max length 255 characters | Retail price excluding tax. |
 | `retailPriceInclTax` | string | required, max length 255 characters | Retail price including tax. |
@@ -147,7 +147,7 @@ Below is a list of all possible fields this endpoint can return including relati
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
 | `name` | string | required, max length 255 characters | Name of the modifier set. |
-| `selection` | string | required | Modifier set selection type. |
+| `selection` | string | required | Modifier set selection type. Possible values are "single" and "multiple". |
 | `maximumCount` | integer | required | Maximum number of modifiers that can be selected. |
 | `minimumCount` | integer | required | Minimum number of modifiers that must be selected. |
 | `createdAt` | string | required, max length 25 characters | Created at timestamp in RFC 3339 format. |

--- a/operations/tables.md
+++ b/operations/tables.md
@@ -26,6 +26,14 @@ This operation returns a list of restaurant tables.
         "numberOfSeats": 4,
         "createdAt": "2024-11-13T11:29:00Z",
         "updatedAt": "2024-11-15T11:29:00Z"
+      },
+      "relationships": {
+        "area": {
+          "data": {
+            "id": "c53372e2-9aa1-452a-8965-2ea3fa514fb2",
+            "type": "areas"
+          }
+        }
       }
     }
   ],
@@ -49,6 +57,7 @@ Below is a list of all possible fields this endpoint can return including relati
 | `id` | string | required, max length 36 characters | Universally unique ID (UUID) that identifies the related object. |
 | `type` | string | required | The [type](https://jsonapi.org/format/#document-resource-object-identification) member is used to describe resource objects that share common attributes and relationships. |
 | `attributes` | [table_attributes](tables.md#table_attributes) | required | An [attributes object](https://jsonapi.org/format/#document-resource-object-attributes) representing some of the resource's data. |
+| `relationships` | [area_relationships](tables.md#area_relationships) | required | A [relationships object](https://jsonapi.org/format/#document-resource-object-relationships) describing relationships between the resource and other JSON:API resources. |
 
 #### table_attributes
 
@@ -58,6 +67,12 @@ Below is a list of all possible fields this endpoint can return including relati
 | `numberOfSeats` | integer | required | Number of seats for the table. |
 | `createdAt` | string | required, max length 25 characters | Created at timestamp in RFC 3339 format. |
 | `updatedAt` | string | required, max length 25 characters | Updated at timestamp in RFC 3339 format. |
+
+#### area_relationships
+
+| Property | Type | Contract | Description |
+| :-- | :-- | :-- | :-- |
+| `area` | object | required | Details of the table area. |
 
 #### table_pagination_links
 

--- a/operations/webhookendpoints.md
+++ b/operations/webhookendpoints.md
@@ -1,12 +1,12 @@
 <!-- AUTOMATICALLY GENERATED, DO NOT MODIFY -->
-# Webhook endpoints
+# WebhookEndpoints
 
-## Create webhook endpoint
+## Create Webhook endpoint
 
-A webhook endpoint represents a URL configured by a merchant to receive notifications for specific events. 
-Merchants can subscribe to various events and provide a target URL where the system will send event data.
+Use this operation to register a Webhook with Mews to receive notification events that you subscribed to.
+For more information, including details about supported events, see [API Events](../events/README.md).
 
-**Note:** This operation needs [Authentication](../essential-guide/authentication.md).
+**Note:** This operation needs [Authentication](../guidelines/authentication.md).
 
 ### Request
 
@@ -54,11 +54,7 @@ Below is a list of all possible fields this endpoint can return including relati
 
 | Property | Type | Contract | Description |
 | :-- | :-- | :-- | :-- |
-| `data` | [webhook_endpoint_attributes](webhookendpoints.md#webhook_endpoint_attributes) | required | The document's "primary data". |
-
-#### webhook_endpoint_attributes
-
-| Property | Type | Contract | Description |
-| :-- | :-- | :-- | :-- |
-| `targetUrl` | string | required, max length 100 characters | A URL configured by a merchant to receive notifications for specific events. |
+| `targetUrl` | string | required, max length 100 characters | The Webhook URL configured to receive event notifications from Mews. |
 | `secret` | string | required, max length 100 characters | A string generated to ensure the authenticity of the webhook. It is used to verify that the webhook request comes from a trusted source. |
+| `createdAt` | string | required, max length 25 characters | Created at timestamp in RFC 3339 format. |
+| `updatedAt` | string | required, max length 25 characters | Updated at timestamp in RFC 3339 format. |


### PR DESCRIPTION
### Summary

* Updated booking relationship with orders (multiple orders now related to booking instead of one).
* Added list of booking statuses.
* Added two new fields, `depositAmount` and `isWalkIn`, for booking attributes.
* Updated bookings list endpoint filters.
* Updated product status enum list.
* Update tables relationships, now it is related to `area`.
* General improvements for webhook endpoint documentation page.

### Checklist

- [ ] Documentation follows the [Style Guide](https://mews.atlassian.net/wiki/x/KJAoCw)
- [ ] JSON examples updated
- [ ] Properties in JSON examples are in the same order as in property tables
- [ ] Changelog dated the day when PR merged
- [ ] Changelog accurately describes all changes
- [ ] Changelog highlights the affected endpoints or operations
- [ ] Changelog highlights any deprecations
- [ ] All hyperlinks tested
- [ ] Deprecation Table updated if any deprecations
- [ ] SUMMARY.md updated if new pages added
